### PR TITLE
Fix for bug #125

### DIFF
--- a/aw-reporting-model/src/main/java/com/google/api/ads/adwords/awreporting/model/util/DateUtil.java
+++ b/aw-reporting-model/src/main/java/com/google/api/ads/adwords/awreporting/model/util/DateUtil.java
@@ -159,7 +159,7 @@ public final class DateUtil {
       for (DateTimeFormatter formatter : DateUtil.formatters) {
         try {
           LocalDateTime localDateTime = formatter.parseLocalDateTime(timestamp);
-          return localDateTime.plusHours(12).toDateTime(DateTimeZone.UTC);
+          return localDateTime.toDateTime(DateTimeZone.UTC);
 
         } catch (IllegalArgumentException e) {
           // silently skips to the next formatter


### PR DESCRIPTION
Removed date offset by 12 hours.

Hi Gustavo,

As per my comments, I have removed a 12 hour offset inserted by the date formatter.  As far as I can see, we don't need the offset, but I'm wondering why it was added in.  Any idea??

Joel