### PR TITLE
Update DateReport.java, set Date columnDefinition

### DIFF
--- a/aw-reporting-model/src/main/java/com/google/api/ads/adwords/awreporting/model/entities/DateReport.java
+++ b/aw-reporting-model/src/main/java/com/google/api/ads/adwords/awreporting/model/entities/DateReport.java
@@ -40,7 +40,8 @@ import org.joda.time.LocalDate;
 @MappedSuperclass
 public abstract class DateReport extends Report {
   // Date Segments
-  @Column(name = "Date")
+  // Date column definition set as DATETIME for database, returned as string for ROW_ID
+  @Column(name = "Date", columnDefinition="DATETIME")
   @CsvField(value = "Day", reportField = "Date")
   protected String date;
 


### PR DESCRIPTION
Setting columnDefinition as "DATETIME" to avoid MySQL query issues when performing date range queries on AW Report tables.

Date columns should be set as DATE/DATETIME, rather than VARCHAR/Strings in order to ensure software built on top will function correctly.

Setting the @column definition with an additional supported property of "columnDefinition='DATETIME'" fixes the issue of date columns not reflecting proper DATETIME configuration, and still allows ROW_ID date to be returned as String for other functions.